### PR TITLE
Push plugin error handling

### DIFF
--- a/src/push/push.ts
+++ b/src/push/push.ts
@@ -229,6 +229,10 @@ export class Push implements IPush {
             this.token.registered = true;
             deferred.resolve(this.token);
           });
+          _this.plugin.on('error', function (err) {
+            _this.logger.error('Ionic Push: ', err);
+            deferred.reject(new Error('Push plugin failed to initialize! See logs.'));
+          });
           this._callbackRegistration();
           this.registered = true;
         } else {

--- a/src/push/push.ts
+++ b/src/push/push.ts
@@ -229,8 +229,8 @@ export class Push implements IPush {
             this.token.registered = true;
             deferred.resolve(this.token);
           });
-          _this.plugin.on('error', function (err) {
-            _this.logger.error('Ionic Push: ', err);
+          this.plugin.on('error', function (err) {
+            this.logger.error('Ionic Push: ', err);
             deferred.reject(new Error('Push plugin failed to initialize! See logs.'));
           });
           this._callbackRegistration();

--- a/src/push/push.ts
+++ b/src/push/push.ts
@@ -229,7 +229,7 @@ export class Push implements IPush {
             this.token.registered = true;
             deferred.resolve(this.token);
           });
-          this.plugin.on('error', function (err) {
+          this.plugin.on('error', (err) => {
             this.logger.error('Ionic Push: ', err);
             deferred.reject(new Error('Push plugin failed to initialize! See logs.'));
           });


### PR DESCRIPTION
Added necessary error handling to Push.register(). Test by attempting Push plugin initialization on non-supported device, e.g. the iPhone Simulator.