### PR TITLE
Load deploy on init

### DIFF
--- a/src/deploy/deploy.ts
+++ b/src/deploy/deploy.ts
@@ -72,6 +72,7 @@ export class Deploy implements IDeploy {
       }
 
       this.emitter.emit('deploy:ready');
+      this.load();
     });
   }
 


### PR DESCRIPTION
Load deploy when the cloud is initialized.  Easier than handling on the plugin level.