### PR TITLE
Ionic Native 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,20 @@
   "typings": "dist/es5/index.d.ts",
   "module": "dist/esm/index.js",
   "dependencies": {
-    "ionic-native": "^2.2.11",
     "superagent": "1.7.2",
     "@ionic/db": "^0.1.0"
   },
+  "peerDependencies": {
+    "@ionic-native/core": "^3.0.0",
+    "@ionic-native/device": "^3.0.0",
+    "@ionic-native/facebook": "^3.0.0",
+    "@ionic-native/google-plus": "^3.0.0"
+  },
   "devDependencies": {
+    "@ionic-native/core": "^3.0.0",
+    "@ionic-native/device": "^3.0.0",
+    "@ionic-native/facebook": "^3.0.0",
+    "@ionic-native/google-plus": "^3.0.0",
     "babel-plugin-external-helpers": "^6.8.0",
     "babel-preset-es2015": "^6.14.0",
     "browserify": "^13.1.0",

--- a/src/angular.ts
+++ b/src/angular.ts
@@ -1,3 +1,7 @@
+import { Device as NativeDevice } from '@ionic-native/device';
+import { Facebook } from '@ionic-native/facebook';
+import { GooglePlus } from '@ionic-native/google-plus';
+
 import { Container as DIContainer } from './di';
 import { EventEmitter } from './events';
 import { DeferredPromise } from './promise';
@@ -12,7 +16,7 @@ export function bootstrapAngular1() {
     return; // No global angular--this is not an AngularJS project.
   }
 
-  let container = new DIContainer();
+  let container = new DIContainer(new NativeDevice(), new Facebook(), new GooglePlus());
 
   angular.element(document).ready(function() {
     container.core.init();

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,4 +1,5 @@
-import { Facebook, FacebookLoginResponse, GooglePlus } from 'ionic-native';
+import { Facebook, FacebookLoginResponse } from '@ionic-native/facebook';
+import { GooglePlus } from '@ionic-native/google-plus';
 
 import {
   APIResponseErrorDetails,
@@ -631,6 +632,13 @@ export abstract class NativeAuth {
  * @featured
  */
 export class GoogleAuth extends NativeAuth implements IGoogleAuth {
+  private googlePlus: GooglePlus;
+
+  constructor(deps: NativeAuthDependencies) {
+    super(deps);
+
+    this.googlePlus = deps.googlePlus;
+  }
 
   public logout(): Promise<void> {
     let deferred = new DeferredPromise<void, Error>();
@@ -641,7 +649,7 @@ export class GoogleAuth extends NativeAuth implements IGoogleAuth {
     user.unstore();
     user.clear();
 
-    GooglePlus.logout().then( () => {
+    this.googlePlus.logout().then( () => {
       deferred.resolve();
     }, (err) => {
       deferred.reject(err);
@@ -657,7 +665,7 @@ export class GoogleAuth extends NativeAuth implements IGoogleAuth {
     this.emitter.once('cordova:deviceready', () => {
       let scope = ['profile', 'email'];
 
-      if (!GooglePlus) {
+      if (!this.googlePlus) {
         deferred.reject(new Error('Ionic native is not installed'));
         return;
       }
@@ -685,7 +693,7 @@ export class GoogleAuth extends NativeAuth implements IGoogleAuth {
         });
       }
 
-      GooglePlus.login({'webClientId': authConfig.google.webClientId, 'offline': true, 'scopes': scope.join(' ')}).then((success) => {
+      this.googlePlus.login({'webClientId': authConfig.google.webClientId, 'offline': true, 'scopes': scope.join(' ')}).then((success) => {
         if (!success.serverAuthCode) {
           deferred.reject(new Error('Failed to retrieve offline access token.'));
           return;
@@ -727,6 +735,13 @@ export class GoogleAuth extends NativeAuth implements IGoogleAuth {
  * @featured
  */
 export class FacebookAuth extends NativeAuth implements IFacebookAuth {
+  private facebook: Facebook;
+
+  constructor(deps: NativeAuthDependencies) {
+    super(deps);
+
+    this.facebook = deps.facebook;
+  }
 
   public logout(): Promise<void> {
     let deferred = new DeferredPromise<void, Error>();
@@ -738,7 +753,7 @@ export class FacebookAuth extends NativeAuth implements IFacebookAuth {
     user.clear();
 
     // Clear the facebook auth.
-    Facebook.logout().then( () => {
+    this.facebook.logout().then( () => {
       deferred.resolve();
     }, (err) => {
       deferred.reject(err);
@@ -761,7 +776,7 @@ export class FacebookAuth extends NativeAuth implements IFacebookAuth {
     }
 
     this.emitter.once('cordova:deviceready', () => {
-      if (!Facebook) {
+      if (!this.facebook) {
         deferred.reject(new Error('Ionic native is not installed'));
         return;
       }
@@ -776,7 +791,7 @@ export class FacebookAuth extends NativeAuth implements IFacebookAuth {
         return;
       }
 
-      Facebook.login(scope).then((r: FacebookLoginResponse) => {
+      this.facebook.login(scope).then((r: FacebookLoginResponse) => {
         scope.splice(scope.indexOf('public_profile'), 1);
         const request_object = {
           'app_id': this.config.get('app_id'),

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,4 +1,6 @@
-import { Device as NativeDevice } from 'ionic-native';
+import { Facebook } from '@ionic-native/facebook';
+import { GooglePlus } from '@ionic-native/google-plus';
+import { Device as NativeDevice } from '@ionic-native/device';
 import { IonicDBOptions } from '@ionic/db';
 
 /**
@@ -290,7 +292,7 @@ export interface DeviceIsConnectedToNetworkOptions {
  * @hidden
  */
 export interface DeviceDependencies {
-  nativeDevice: typeof NativeDevice;
+  nativeDevice: NativeDevice;
   emitter: IEventEmitter;
 }
 
@@ -298,7 +300,7 @@ export interface DeviceDependencies {
  * @hidden
  */
 export interface IDevice {
-  native: typeof NativeDevice;
+  native: NativeDevice;
   type: string;
 
   isAndroid(): boolean;
@@ -834,7 +836,7 @@ export interface AuthDependencies {
 }
 
 /**
- * @hidden 
+ * @hidden
  */
 export interface NativeAuthDependencies {
   config: IConfig;
@@ -843,6 +845,8 @@ export interface NativeAuthDependencies {
   storage: IStorage<string>;
   tokenContext: ICombinedTokenContext;
   emitter: IEventEmitter;
+  facebook: Facebook;
+  googlePlus: GooglePlus;
 }
 
 /**

--- a/src/device.ts
+++ b/src/device.ts
@@ -1,4 +1,4 @@
-import { Device as NativeDevice } from 'ionic-native';
+import { Device as NativeDevice } from '@ionic-native/device';
 
 import {
   DeviceDependencies,
@@ -15,7 +15,7 @@ declare var navigator: any;
  */
 export class Device implements IDevice {
 
-  public native: typeof NativeDevice;
+  public native: NativeDevice;
 
   public type: string;
 

--- a/src/di.ts
+++ b/src/di.ts
@@ -1,4 +1,6 @@
-import { Device as NativeDevice } from 'ionic-native';
+import { Device as NativeDevice } from '@ionic-native/device';
+import { Facebook } from '@ionic-native/facebook';
+import { GooglePlus } from '@ionic-native/google-plus';
 import { IonicDBOptions } from '@ionic/db';
 
 import {
@@ -82,6 +84,7 @@ function cache<T>(target: any, propertyKey: string, descriptor: TypedPropertyDes
  * @hidden
  */
 export class Container {
+  constructor(private nativeDevice: NativeDevice, private facebook: Facebook, private googlePlus: GooglePlus) { }
 
   @cache
   public get appStatus(): AppStatus {
@@ -165,7 +168,7 @@ export class Container {
 
   @cache
   public get device(): IDevice {
-    return new Device({'nativeDevice': NativeDevice, 'emitter': this.eventEmitter});
+    return new Device({'nativeDevice': this.nativeDevice, 'emitter': this.eventEmitter});
   }
 
   @cache
@@ -228,7 +231,9 @@ export class Container {
       'userService': this.singleUserService,
       'storage': new Storage<string>({'strategy': this.localStorageStrategy}),
       'tokenContext': this.authTokenContext,
-      'emitter': this.eventEmitter
+      'emitter': this.eventEmitter,
+      'facebook': this.facebook,
+      'googlePlus': this.googlePlus
     });
   }
 
@@ -240,7 +245,9 @@ export class Container {
       'userService': this.singleUserService,
       'storage': new Storage<string>({'strategy': this.localStorageStrategy}),
       'tokenContext': this.authTokenContext,
-      'emitter': this.eventEmitter
+      'emitter': this.eventEmitter,
+      'facebook': this.facebook,
+      'googlePlus': this.googlePlus
     });
   }
 

--- a/src/insights.ts
+++ b/src/insights.ts
@@ -224,7 +224,7 @@ export class Insights implements IInsights {
    * @private
    */
   protected shouldSubmit(): boolean {
-    return this.batch.length >= this.options.submitCount;
+    return this.batch.length >= (this.options.submitCount || 0);
   }
 
   /**


### PR DESCRIPTION
Hi. We want to use Ionic Native 3.x, which is currently not possible with `@ionic/cloud@0.16.0`.

As #190 has been opened a while ago, I wanted to help with this.
As all native plugins have to be instantiated (ideally through injection), I added them to the `DIContainer` class.

When trying `npm run build` it failed on master.